### PR TITLE
Fix GHC warning on import

### DIFF
--- a/src/Hemmet/BEM/Rendering.hs
+++ b/src/Hemmet/BEM/Rendering.hs
@@ -6,7 +6,7 @@ module Hemmet.BEM.Rendering
 
 import Control.Monad
 import Data.Foldable
-import Data.List as L
+import Data.List as L ( zip, map, concatMap, sort )
 import Data.Text as T
 
 import Hemmet.Rendering

--- a/src/Hemmet/FileTree/Rendering.hs
+++ b/src/Hemmet/FileTree/Rendering.hs
@@ -5,7 +5,7 @@ module Hemmet.FileTree.Rendering
 
 import Control.Monad
 import Data.Function
-import Data.List
+import Data.List ( sortBy )
 
 import Hemmet.Rendering
 import Hemmet.Tree


### PR DESCRIPTION
```
    To ensure compatibility with future core libraries changes
    imports to Data.List should be
    either qualified or have an explicit import list.
```